### PR TITLE
Fix absolute path for libgtest_main.a

### DIFF
--- a/buildit.sh
+++ b/buildit.sh
@@ -1,4 +1,4 @@
 rm -f *.o TestStringReverser
 g++ $(gtest-config --cppflags --cxxflags) -o TestStringReverser.o -c TestStringReverser.cpp \
-&& g++ $(gtest-config --ldflags --libs) -o TestStringReverser TestStringReverser.o /usr/lib/libgtest_main.a \
+&& g++ $(gtest-config --ldflags --libs) -o TestStringReverser TestStringReverser.o $(gtest-config --libdir)/libgtest_main.a \
 && ./TestStringReverser


### PR DESCRIPTION
Uses gtest-config to find the correct library path, instead of assuming /usr/local/.
